### PR TITLE
Add Postgres support and update drone.toml template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,11 @@ drone_session_expires: '72h'
 drone_smtp_port: '25'
 drone_smtp_address: 'drone@drone.io'
 
-drone_open_invitations: False
+drone_github_open: false
+drone_github_enterprise_open: false
+drone_bitbucket_open: false
+drone_gitlab_open: false
+drone_gogs_open: false
 
 drone_github_enteprise_private_mode: False
 drone_github_enteprise_skip_verify: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ drone_github_enteprise_skip_verify: False
 
 drone_worker_nodes:
   - 'unix:///var/run/docker.sock'
+  - 'unix:///var/run/docker.sock'
 
 drone_database_driver: sqlite3
 drone_database_datasource: /var/lib/drone/drone.sqlite

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Validate database driver
   assert:
     that:
-      - drone_database_driver in ['sqlite3', 'mysql']
+      - drone_database_driver in ['sqlite3', 'mysql', 'postgres']
 
 - name: Install dependencies via apt
   apt:
@@ -90,6 +90,15 @@
     mode: 0600
   when: drone_database_driver == 'mysql'
 
+- name: Template pgsql file for drone database configuration
+  template:
+    src: drone.pgsql.sql.j2
+    dest: /etc/drone/drone.pgsql.sql
+    owner: root
+    group: root
+    mode: 0600
+  when: drone_database_driver == 'postgres'
+
 - name: Template TOML file for drone daemon configuration
   template:
     src: drone.toml.j2
@@ -126,6 +135,18 @@
   register: drone_after_hash
   changed_when: drone_after_hash.stdout|default('')|trim != drone_before_hash.stdout|default('')|trim
   when: drone_database_driver == 'mysql'
+
+- name: Hash postgresql tables to validate change
+  shell: "psql drone drone -e -c 'SELECT * FROM users;' | md5sum"
+  register: drone_before_hash
+  changed_when: False
+  when: drone_database_driver == 'postgres'
+
+- name: Configure postgresql drone database settings
+  shell: "psql drone drone -f /etc/drone/drone.pgsql.sql && psql -e -c 'SELECT * FROM users;' | md5sum"
+  register: drone_after_hash
+  changed_when: drone_after_hash.stdout|default('')|trim != drone_before_hash.stdout|default('')|trim
+  when: drone_database_driver == 'postgres'
 
 - name: Ensure drone is started
   service:

--- a/templates/drone.pgsql.sql.j2
+++ b/templates/drone.pgsql.sql.j2
@@ -1,0 +1,43 @@
+{% for user in drone_users %}
+{% if user['state']|default('present') == 'absent' %}
+DELETE FROM users WHERE user_remote = '{{ user_remote }}' and user_login = '{{ user.login }}';
+{% else %}
+INSERT INTO users
+    (
+        user_remote,
+        user_login,
+        user_access,
+        user_secret,
+        user_name,
+        user_email,
+        user_gravatar,
+        user_token,
+        user_admin,
+        user_active,
+        user_syncing,
+        user_created,
+        user_updated,
+        user_synced
+    )
+    VALUES (
+        '{{ user.remote }}",
+        '{{ user.login }}",
+        '',
+        '',
+        '',
+        '',
+        '{{ ''|md5 }}',
+        '{{ (user.remote ~ user.login)|md5|b64encode|truncate(40, True, '') }}',
+        {{ user["admin"]|default(False)|int }},
+        {{ user["active"]|default(True)|int }},
+        0,
+        0,
+        0,
+        0
+    )
+    ON DUPLICATE KEY UPDATE
+        user_admin={{ user["admin"]|default(False)|int }},
+        user_active={{ user["active"]|default(True)|int }}
+    ;
+{% endif %}
+{% endfor %}

--- a/templates/drone.toml.j2
+++ b/templates/drone.toml.j2
@@ -1,13 +1,13 @@
 [server]
 port=":{{ drone_port }}"
 
-[session]
-secret="{{ drone_session_secret | default("") }}"
-expires="{{ drone_session_expires }}"
-
 [server.ssl]
 key="{{ drone_sslkey | default("") }}"
 cert="{{ drone_sslcert | default("") }}"
+
+[session]
+secret="{{ drone_session_secret | default("") }}"
+expires="{{ drone_session_expires }}"
 
 [database]
 driver="{{ drone_database_driver }}"
@@ -26,7 +26,6 @@ secret="{{ drone_github_enteprise_secret | default("") }}"
 api="{{ drone_github_enteprise_api_url | default("") }}"
 url="{{ drone_github_enteprise_url | default("") }}"
 private_mode={{ drone_github_enteprise_private_mode|bool|string|lower | default("") }}
-skip_verify={{ drone_github_enteprise_skip_verify|bool|string|lower | default("") }}
 
 [bitbucket]
 client="{{ drone_bitbucket_client | default("") }}"
@@ -46,12 +45,13 @@ from="{{ drone_smtp_address | default("") }}"
 user="{{ drone_smtp_username | default("") }}"
 pass="{{ drone_smtp_password | default("") }}"
 
+[docker]
+cert="{{ drone_docker_cert | default("") }}"
+key="{{ drone_docker_cert | default("") }}"
+
 [worker]
-cert="{{ drone_worker_cert | default("") }}"
-key="{{ drone_worker_key | default("") }}"
 nodes=[
 {% for worker in drone_worker_nodes %}
-  "{{ worker }}"{{ "," if not loop.last }}
+  "{{ worker }}"{{ "," if not loop.last else "" }}
 {% endfor %}
 ]
-

--- a/templates/drone.toml.j2
+++ b/templates/drone.toml.j2
@@ -13,12 +13,10 @@ expires="{{ drone_session_expires }}"
 driver="{{ drone_database_driver }}"
 datasource="{{ drone_database_datasource }}"
 
-[registration]
-open={{ drone_open_invitations|bool|string|lower }}
-
 [github]
 client="{{ drone_github_client | default("") }}"
 secret="{{ drone_github_secret | default("") }}"
+open={{ drone_github_open|bool|string|lower | default("") }}
 
 [github_enterprise]
 client="{{ drone_github_enteprise_client | default("") }}"
@@ -26,17 +24,21 @@ secret="{{ drone_github_enteprise_secret | default("") }}"
 api="{{ drone_github_enteprise_api_url | default("") }}"
 url="{{ drone_github_enteprise_url | default("") }}"
 private_mode={{ drone_github_enteprise_private_mode|bool|string|lower | default("") }}
+open={{ drone_github_enterprise_open|bool|string|lower | default("") }}
 
 [bitbucket]
 client="{{ drone_bitbucket_client | default("") }}"
 secret="{{ drone_bitbucket_secret | default("") }}"
+open={{ drone_bitbucket_open|bool|string|lower | default("") }}
 
 [gitlab]
 url="{{ drone_gitlab_url | default("") }}"
+open={{ drone_gitlab_open|bool|string|lower | default("") }}
 
 [gogs]
 url="{{ drone_gogs_url | default("") }}"
 secret="{{ drone_gogs_secret | default("") }}"
+open={{ drone_gogs_open|bool|string|lower | default("") }}
 
 [smtp]
 host="{{ drone_smtp_server | default("") }}"

--- a/templates/drone.toml.j2
+++ b/templates/drone.toml.j2
@@ -2,16 +2,12 @@
 port=":{{ drone_port }}"
 
 [session]
-{% if drone_session_secret %}
-secret="{{ drone_session_secret }}"
-{%- endif %}
+secret="{{ drone_session_secret | default("") }}"
 expires="{{ drone_session_expires }}"
 
-{% if drone_sslcert and drone_sslkey -%}
 [server.ssl]
-key="{{ drone_sslkey }}"
-cert="{{ drone_sslcert }}"
-{%- endif %}
+key="{{ drone_sslkey | default("") }}"
+cert="{{ drone_sslcert | default("") }}"
 
 [database]
 driver="{{ drone_database_driver }}"
@@ -20,57 +16,42 @@ datasource="{{ drone_database_datasource }}"
 [registration]
 open={{ drone_open_invitations|bool|string|lower }}
 
-{% if drone_github_client and drone_github_secret -%}
 [github]
-client="{{ drone_github_client }}"
-secret="{{ drone_github_secret }}"
-{%- endif %}
+client="{{ drone_github_client | default("") }}"
+secret="{{ drone_github_secret | default("") }}"
 
-{% if drone_github_enterprise_client and drone_github_enteprise_secret and drone_github_enteprise_api_url and drone_github_enteprise_url -%}
 [github_enterprise]
-client="{{ drone_github_enteprise_client }}"
-secret="{{ drone_github_enteprise_secret }}"
-api="{{ drone_github_enteprise_api_url }}"
-url="{{ drone_github_enteprise_url }}"
-private_mode={{ drone_github_enteprise_private_mode|bool|string|lower }}
-skip_verify={{ drone_github_enteprise_skip_verify|bool|string|lower }}
-{%- endif %}
+client="{{ drone_github_enteprise_client | default("") }}"
+secret="{{ drone_github_enteprise_secret | default("") }}"
+api="{{ drone_github_enteprise_api_url | default("") }}"
+url="{{ drone_github_enteprise_url | default("") }}"
+private_mode={{ drone_github_enteprise_private_mode|bool|string|lower | default("") }}
+skip_verify={{ drone_github_enteprise_skip_verify|bool|string|lower | default("") }}
 
-{% if drone_bitbucket_client and drone_bitbucket_secret -%}
 [bitbucket]
-client="{{ drone_bitbucket_client }}"
-secret="{{ drone_bitbucket_secret }}"
-{%- endif %}
+client="{{ drone_bitbucket_client | default("") }}"
+secret="{{ drone_bitbucket_secret | default("") }}"
 
-{% if drone_gitlab_url -%}
 [gitlab]
-url="{{ drone_gitlab_url }}"
-{%- endif %}
+url="{{ drone_gitlab_url | default("") }}"
 
-{% if drone_gogs_secret and drone_gogs_url %}
 [gogs]
-url="{{ drone_gogs_url }}"
-secret="{{ drone_gogs_secret }}"
-{% endif %}
+url="{{ drone_gogs_url | default("") }}"
+secret="{{ drone_gogs_secret | default("") }}"
 
-{% if drone_smtp_server -%}
 [smtp]
-host="{{ drone_smtp_server }}"
-port="{{ drone_smtp_port }}"
-from="{{ drone_smtp_address }}"
-{% if drone_smtp_username and drone_smtp_password %}
-user="{{ drone_smtp_username }}"
-pass="{{ drone_smtp_password }}"
-{% endif %}
-{%- endif %}
+host="{{ drone_smtp_server | default("") }}"
+port="{{ drone_smtp_port | default("") }}"
+from="{{ drone_smtp_address | default("") }}"
+user="{{ drone_smtp_username | default("") }}"
+pass="{{ drone_smtp_password | default("") }}"
 
 [worker]
-{% if drone_worker_cert and drone_worker_key %}
-cert="{{ drone_worker_cert }}"
-key="{{ drone_worker_key }}"
-{% endif %}
+cert="{{ drone_worker_cert | default("") }}"
+key="{{ drone_worker_key | default("") }}"
 nodes=[
 {% for worker in drone_worker_nodes %}
   "{{ worker }}"{{ "," if not loop.last }}
 {% endfor %}
 ]
+


### PR DESCRIPTION
This PR adds support for postgres (tested and works for me)

I also updated the `drone.toml.j2` to be consistent with [the one in drone/drone] (https://github.com/drone/drone/blob/master/packaging/root/etc/drone/drone.toml).

When I ran the my playbook, Ansible complained if "every" tunable in the TOML file wasn't present.
It's likely a peculiarity of Ansible, but I removed the conditionals and replaced this with a default to "", so effectively all tunable fields  are now optional.

I tested this with a deploy today and it works great! Thanks for this module