### PR TITLE
defaults for drone_sslkey and drone_sslcert vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@ drone_port: 80
 drone_session_expires: '72h'
 drone_session_secret: ~
 
+drone_sslkey: false
+drone_sslcert: false
+
 drone_smtp_port: '25'
 drone_smtp_address: 'drone@drone.io'
 drone_smtp_server: ~


### PR DESCRIPTION
this fixes the following error during a play:

    TASK: [sivel.drone | Template TOML file for drone daemon configuration] *******
    fatal: [tools] => {'msg': "AnsibleUndefinedVariable: One or more undefined variables: 'drone_sslcert' is undefined", 'failed': True}
    fatal: [tools] => {'msg': "AnsibleUndefinedVariable: One or more undefined variables: 'drone_sslcert' is undefined", 'failed': True}

    FATAL: all hosts have already failed -- aborting