### PR TITLE
drone.deb has been moved from /latest/ to /master/

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Download drone.deb
   get_url:
-    url: http://downloads.drone.io/latest/drone.deb
+    url: http://downloads.drone.io/master/drone.deb
     dest: /tmp/drone.deb
     force: "{{ install_drone|default(False)|bool }}"
   register: drone_get


### PR DESCRIPTION
Fix of a bug: 
TASK: [sivel.drone | Download drone.deb] ************************************** 
failed: [104.131.92.175] => {"dest": "/tmp/drone.deb", "failed": true, "response": "HTTP Error 403: Forbidden", "state": "absent", "status_code": 403, "url": "http://downloads.drone.io/latest/drone.deb"}