### PR TITLE
docker-py version up; ssl settings now not required

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     version: "{{ item.version }}"
   with_items:
     - name: docker-py
-      version: 0.6.0
+      version: 1.2.3
 
 - name: Check for drone
   stat:

--- a/templates/drone.toml.j2
+++ b/templates/drone.toml.j2
@@ -7,7 +7,7 @@ secret="{{ drone_session_secret }}"
 {%- endif %}
 expires="{{ drone_session_expires }}"
 
-{% if drone_sslcert and drone_sslkey -%}
+{% if drone_scheme is equalto "https" -%}
 [server.ssl]
 key="{{ drone_sslkey }}"
 cert="{{ drone_sslcert }}"


### PR DESCRIPTION
Hi!

Here is some fixes:
 - docker-py version was increased up to 1.2.3
 - ssl settings now not required if scheme is set to http